### PR TITLE
Update Gruntfile.js

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -15,7 +15,7 @@ module.exports = function(grunt) {
         livereload: true,
       },
       express: {
-        files:  [ '*.js','routes/*.js', 'models/*.js', 'config/*.js' ],
+        files:  [ '*.js','routes/*.js', 'models/*.js', 'config/*.js','api/*.js'  ],
         tasks:  [ 'express:dev' ],
         options: {
           spawn: false // Without this option specified express won't be reloaded


### PR DESCRIPTION
'api' directory was not being watched and as a result, any modifications made int he directory did not cause the server to restart.
